### PR TITLE
Hook in before LXC providers as well as VirtualBox

### DIFF
--- a/lib/vagrant-vlan/debian/configure_vlans.rb
+++ b/lib/vagrant-vlan/debian/configure_vlans.rb
@@ -13,8 +13,10 @@ module VagrantPlugins
         def self.configure_vlans(machine, vlans)
           machine.communicate.tap do |comm|
             # Verify the kernel module is installed and loaded.
-            if !comm.test("lsmod | grep 8021q")
+            if !comm.test("dpkg -l | grep vlan")
               comm.sudo("apt-get install vlan")
+            end
+            if !comm.test("lsmod | grep 8021q")
               comm.sudo("modprobe 8021q")
             end
 

--- a/lib/vagrant-vlan/plugin.rb
+++ b/lib/vagrant-vlan/plugin.rb
@@ -15,8 +15,16 @@ module VagrantPlugins
         # configuration middleware) do the actual network configuration on the
         # way up the middleware stack. Therefore, this ensures that we will
         # configure the vlans after the rest of the interfaces.
+
+        # Hook in before VirtualBox provider
         hook.before(VagrantPlugins::ProviderVirtualBox::Action::Network,
                     Action)
+
+        if Vagrant.has_plugin?("vagrant-lxc")
+          require "vagrant-lxc/action"
+          # Hook in before LXC provider if we have one
+          hook.before(Vagrant::LXC::Action::PrivateNetworks, Action)
+        end
       end
 
       config "vlan" do

--- a/lib/vagrant-vlan/version.rb
+++ b/lib/vagrant-vlan/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module VLAN
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
**Description:** Add support for vagrant-lxc to this plugin

**Testing:** Use the plugin in an environment that uses the VirtualBox provider, and one that uses the vagrant-lxc provider. Make sure both work as expected
